### PR TITLE
Connect to write node to avoid returning stale data

### DIFF
--- a/helm/relations-api/templates/deployment.yaml
+++ b/helm/relations-api/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
           valueFrom:
             configMapKeyRef:
               name: global-config
-              key: neo4j.read.only.url
+              key: neo4j.read.write.url
         ports:
         - containerPort: 8080
         livenessProbe:


### PR DESCRIPTION
# Description

## What

The relations-api is redirected to connect to neo4j write node to avoid returning stale data.

This is critical for the upp-notifications-creator service

## Why

[UPPSF-1849](https://financialtimes.atlassian.net/browse/UPPSF-1849)

## Anything, in particular, you'd like to highlight to reviewers

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [X] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
