### PR TITLE
Use new neo4j connectivity check

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/Financial-Times/api-endpoint v1.0.0
-	github.com/Financial-Times/cm-neo4j-driver v0.0.1
+	github.com/Financial-Times/cm-neo4j-driver v0.1.1
 	github.com/Financial-Times/content-collection-rw-neo4j v0.0.0-20170322121701-b3ba6c46f8d7
 	github.com/Financial-Times/content-rw-neo4j v1.0.3-0.20180613151118-5543bceb064c
 	github.com/Financial-Times/go-fthealth v0.0.0-20181009114238-ca83ad65381f

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/Financial-Times/api-endpoint v1.0.0 h1:EhJfcVcrktPrweue6dCUQAYcEQiXwh+1byIc8a1nypE=
 github.com/Financial-Times/api-endpoint v1.0.0/go.mod h1:QrJsxP8uEZIPJZon+qhc+zO7H0634DpoqDI291i0Nag=
-github.com/Financial-Times/cm-neo4j-driver v0.0.1 h1:AFD0V2LNHJaxhs2kNVc3BDRwnY6uv0hdyWbYk2eONZ0=
-github.com/Financial-Times/cm-neo4j-driver v0.0.1/go.mod h1:0q7rpnzwBxptooh2/cqd9xALfgNEgVF6JLEzw0ygIDQ=
+github.com/Financial-Times/cm-neo4j-driver v0.1.1 h1:rofDjk4/+DpetBHS+lEltJIodOE95J4uWwngbGS4VYQ=
+github.com/Financial-Times/cm-neo4j-driver v0.1.1/go.mod h1:0q7rpnzwBxptooh2/cqd9xALfgNEgVF6JLEzw0ygIDQ=
 github.com/Financial-Times/content-collection-rw-neo4j v0.0.0-20170322121701-b3ba6c46f8d7 h1:BwrTGSAVcqA65TWfkaDn4vWOZVs+iNUmOhayQBOEbGk=
 github.com/Financial-Times/content-collection-rw-neo4j v0.0.0-20170322121701-b3ba6c46f8d7/go.mod h1:LHqzaDKcf9CJvnJlybS4JDyanVcvvbvqD5oKRO4dnnM=
 github.com/Financial-Times/content-rw-neo4j v1.0.3-0.20180613151118-5543bceb064c h1:QwFC8Hq2cX/LNA4MQFcln/nVO3Pj3mlflaPZ03vzmW8=

--- a/relations/cypherDriver.go
+++ b/relations/cypherDriver.go
@@ -22,7 +22,7 @@ func NewCypherDriver(driver *cmneo4j.Driver) Driver {
 }
 
 func (cd *cypherDriver) checkConnectivity() error {
-	return cd.driver.VerifyConnectivity()
+	return cd.driver.VerifyWriteConnectivity()
 }
 
 func (cd *cypherDriver) findContentRelations(contentUUID string) (relations, bool, error) {


### PR DESCRIPTION
This new check called `VerifyWriteConnectivity` will return an error if the
relations-api is not connected to the cluster leader, because it's important for
the clients of the service that it reads the most up-to-date data.

## Scope and particulars of this PR (Please tick all that apply)

- [x] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
